### PR TITLE
Fix Docker Tags

### DIFF
--- a/.github/workflows/push-to-docker.yml
+++ b/.github/workflows/push-to-docker.yml
@@ -12,8 +12,18 @@ jobs:
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
     steps:
-      - name: Check out the repo
+      - name: Checkout the repo
         uses: actions/checkout@v2
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: r0x4r/garud
+          tags: |
+            type=raw,value=latest
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
 
       - name: Login to Docker Hub
         uses: docker/login-action@v1
@@ -24,12 +34,6 @@ jobs:
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v1
-
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v3
-        with:
-          images: frost19k/garud
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v2


### PR DESCRIPTION
Previous version of the file would tag the image as `r0x4r/garud:master`. 

This will return a `repository does not exist` error if the command used is `docker pull r0x4r/garud` because Docker's default tag is `:latest`

Current version creates three tags `latest`, `3.2.1`, `3.2`

Of course, you're gonna need to setup Docker Hub Account & [Access Tokens](https://docs.docker.com/ci-cd/github-actions).